### PR TITLE
feat: add machine-readable markers for hardware validation

### DIFF
--- a/.codex/skills/p4home-hardware-validation/SKILL.md
+++ b/.codex/skills/p4home-hardware-validation/SKILL.md
@@ -17,8 +17,9 @@ Use this skill only in the `p4home` repository.
    - success does not mean the firmware change passed functional validation
 3. Obtain the artifact `esp32-p4-monitor-log`.
 4. Read `hardware-validation-manifest.json` before `monitor.log`.
-5. Check that the artifact belongs to the commit under test.
-6. Judge the firmware change from log evidence, not from the GitHub job color alone.
+5. Use `verification_case` and `expected_markers` from manifest to scope the judgment.
+6. Check that the artifact belongs to the commit under test.
+7. Judge the firmware change from log evidence, not from the GitHub job color alone.
 
 For the exact artifact contract and verdict model, read [references/artifact-contract.md](references/artifact-contract.md).
 

--- a/.codex/skills/p4home-hardware-validation/references/artifact-contract.md
+++ b/.codex/skills/p4home-hardware-validation/references/artifact-contract.md
@@ -33,7 +33,12 @@ Expected manifest shape:
   "job": "flash-and-monitor",
   "serial_port": "/dev/cu.usbserial-10",
   "monitor_seconds": 20,
-  "log_file": "monitor.log"
+  "log_file": "monitor.log",
+  "verification_case": "boot-smoke",
+  "expected_markers": [
+    "VERIFY:boot:board_init:PASS",
+    "VERIFY:display:bootstrap:PASS"
+  ]
 }
 ```
 
@@ -41,6 +46,8 @@ Interpretation:
 
 - `mode=artifact-only`: the workflow does not perform business-level PASS/FAIL checks
 - `verdict_owner=cloud-codex`: Codex must interpret the artifact and decide whether the change worked
+- `verification_case`: names the intended functional scenario for this run
+- `expected_markers`: hints which stable markers should be prioritized in `monitor.log`
 
 ## Minimal Workflow Failure Model
 

--- a/.github/workflows/firmware-self-hosted-flash-serial.yml
+++ b/.github/workflows/firmware-self-hosted-flash-serial.yml
@@ -11,6 +11,10 @@ on:
         description: Seconds to capture startup logs
         required: true
         default: "20"
+      verification_case:
+        description: Functional case name for cloud Codex judgment
+        required: true
+        default: boot-smoke
 
 jobs:
   flash-and-monitor:
@@ -28,6 +32,7 @@ jobs:
     env:
       SERIAL_PORT: ${{ inputs.serial_port }}
       MONITOR_SECONDS: ${{ inputs.monitor_seconds }}
+      VERIFICATION_CASE: ${{ inputs.verification_case }}
       IDF_SKIP_CHECK_SUBMODULES: "1"
     steps:
       - name: Checkout repository
@@ -128,6 +133,11 @@ jobs:
               "serial_port": os.environ["SERIAL_PORT"],
               "monitor_seconds": int(os.environ["MONITOR_SECONDS"]),
               "log_file": "monitor.log",
+              "verification_case": os.environ["VERIFICATION_CASE"],
+              "expected_markers": [
+                  "VERIFY:boot:board_init:PASS",
+                  "VERIFY:display:bootstrap:PASS",
+              ],
           }
 
           pathlib.Path("hardware-validation-manifest.json").write_text(

--- a/docs/cloud-codex-hardware-validation.md
+++ b/docs/cloud-codex-hardware-validation.md
@@ -78,7 +78,12 @@ artifact 内至少包含两个文件：
   "job": "flash-and-monitor",
   "serial_port": "/dev/cu.usbserial-10",
   "monitor_seconds": 20,
-  "log_file": "monitor.log"
+  "log_file": "monitor.log",
+  "verification_case": "boot-smoke",
+  "expected_markers": [
+    "VERIFY:boot:board_init:PASS",
+    "VERIFY:display:bootstrap:PASS"
+  ]
 }
 ```
 
@@ -86,6 +91,8 @@ artifact 内至少包含两个文件：
 
 - `mode=artifact-only` 表示 workflow 不做功能业务裁决
 - `verdict_owner=cloud-codex` 表示最终通过/失败由云端 Codex 解释
+- `verification_case` 表示本次 run 希望验证的功能场景
+- `expected_markers` 给出建议优先检查的串口标记
 
 ## Minimal Workflow Verdict
 
@@ -128,6 +135,19 @@ workflow 不再负责：
 VERIFY:touch:init:PASS
 VERIFY:wifi:connect:FAIL reason=timeout
 VERIFY:settings:migration:PASS
+```
+
+当前固件启动阶段已经输出以下机器可读标记：
+
+```text
+VERIFY:boot:board_init:PASS
+VERIFY:display:bootstrap:<PASS|FAIL>
+VERIFY:touch:detect:<PASS|FAIL>
+VERIFY:touch:lvgl_indev:<PASS|FAIL>
+VERIFY:audio:speaker:<PASS|FAIL>
+VERIFY:audio:microphone:<PASS|FAIL>
+VERIFY:audio:tone_played:<PASS|FAIL>
+VERIFY:audio:mic_capture:<PASS|FAIL>
 ```
 
 这样可以显著降低云端 Codex 解析串口日志的歧义。

--- a/firmware/main/app_main.c
+++ b/firmware/main/app_main.c
@@ -7,6 +7,11 @@
 
 static const char *TAG = "p4home_main";
 
+static void log_verify_marker(const char *area, const char *check, bool pass)
+{
+    ESP_LOGI(TAG, "VERIFY:%s:%s:%s", area, check, pass ? "PASS" : "FAIL");
+}
+
 void app_main(void)
 {
     diagnostics_service_log_boot_banner();
@@ -31,6 +36,15 @@ void app_main(void)
              board_support_audio_tone_played() ? "yes" : "no",
              board_support_audio_microphone_capture_ready() ? "yes" : "no",
              board_support_audio_busy() ? "yes" : "no");
+
+    log_verify_marker("boot", "board_init", true);
+    log_verify_marker("display", "bootstrap", board_support_display_ready());
+    log_verify_marker("touch", "detect", board_support_touch_detected());
+    log_verify_marker("touch", "lvgl_indev", board_support_touch_indev_ready());
+    log_verify_marker("audio", "speaker", board_support_audio_speaker_ready());
+    log_verify_marker("audio", "microphone", board_support_audio_microphone_ready());
+    log_verify_marker("audio", "tone_played", board_support_audio_tone_played());
+    log_verify_marker("audio", "mic_capture", board_support_audio_microphone_capture_ready());
 
     while (true) {
         diagnostics_service_log_runtime_heartbeat();


### PR DESCRIPTION
## Summary
- extend `Firmware Self-Hosted Flash Serial` workflow with a `verification_case` input and include `verification_case` + `expected_markers` in `hardware-validation-manifest.json`
- add startup `VERIFY:<area>:<check>:<PASS|FAIL>` markers in `firmware/main/app_main.c` for boot, display, touch, and audio readiness
- update cloud validation docs and skill references so cloud Codex reads the new manifest fields and prioritizes expected markers

## Why
This continues the cloud-codex hardware validation plan by making functional verification machine-discernible from serial artifacts, instead of relying on generic boot lines.

## Validation
- static inspection only (no runtime execution in this environment)
- reviewed diffs for workflow manifest contract, skill instructions, and firmware log markers consistency

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d32add58808320b8883e9a25fa4d05)